### PR TITLE
Add 'use_static_cpp' option for MinGW builds

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -71,6 +71,7 @@ def get_opts():
         BoolVariable("use_mingw", "Use the Mingw compiler, even if MSVC is installed. Only used on Windows.", False),
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
         BoolVariable("use_thinlto", "Use ThinLTO", False),
+        BoolVariable("use_static_cpp", "When using MinGW, link libgcc, libstdc++ and libpthread statically", True),
     ]
 
 
@@ -373,12 +374,14 @@ def configure_mingw(env):
     mingw_prefix = ""
 
     if env["bits"] == "32":
-        env.Append(LINKFLAGS=["-static"])
-        env.Append(LINKFLAGS=["-static-libgcc"])
-        env.Append(LINKFLAGS=["-static-libstdc++"])
+        if env["use_static_cpp"]:
+            env.Append(LINKFLAGS=["-static"])
+            env.Append(LINKFLAGS=["-static-libgcc"])
+            env.Append(LINKFLAGS=["-static-libstdc++"])
         mingw_prefix = env["mingw_prefix_32"]
     else:
-        env.Append(LINKFLAGS=["-static"])
+        if env["use_static_cpp"]:
+            env.Append(LINKFLAGS=["-static"])
         mingw_prefix = env["mingw_prefix_64"]
 
     if env["use_llvm"]:


### PR DESCRIPTION
The motivation for this change:

While experimenting with compiling Godot myself with the goal of evaluating what it would take to make a game in C++, I stumbled upon something that I think is an issue:

When building Godot with MinGW, the build system is setup in such a way that `libgcc` and `libstdc++` (and `libpthread` apparently) are linked statically. This is very convenient as it produces a single editor/template executable which is easier to distribute without the need to also include 3 other `.dll` files.

However these libraries are licensed under the GPL with the special exception. Correct me if I am wrong, but my understanding is that basically this means that if you link statically to these library, the produced program is considered a derivative work and hence falls under the GPL too.

This is not a problem for the binaries built from the (unmodified) Godot source code, as Godot itself is open-source. However when someone wants to develop a closed-source game by modifying Godot (e.g. by adding internally used modules or making changes directly in the engine), and then compiles using MinGW, they would violate the GPL without even knowing it.

The same option exists in the X11 platform configuration but it is set to `False` by default. I've made this one `True` by default to keep the current behaviour (and because there is no issue for builds with unmodified Godot).

Tested by cross-compiling a 64-bit editor on Ubuntu - with the option set to `yes` and `no`.

Once again, please first verify my assumption. I am not a lawyer but my general understanding from my experience is that only dynamic linking to this libraries is allowed when you want to build a proprietary application.